### PR TITLE
Add additional specifications 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [Open mHealth](http://www.openmhealth.org) - Open Standard For Mobile Health Data.
   * [SMART on FHIR](http://docs.smarthealthit.org/) - Open standards based technology platform.
   * [StandardHealthRecord](http://standardhealthrecord.org/) - Open specification for health record format, aiming to be more precise than existing formats.
-  * [Continuity of Care Document](https://corepointhealth.com/resource-center/hl7-resources/ccd) - Continuity of Care Document overview.
-  * [Continuity of Care Record](https://corepointhealth.com/resource-center/white-papers/understanding-continuity-care-record) - Understanding the Continuity of Care Record.
+  * [Continuity of Care Document](http://www.hl7.org/implement/standards/product_brief.cfm?product_id=7) - Continuity of Care Document specifications (free account required).
+  * [Continuity of Care Record](http://hitsp.org/ConstructSet_Details.aspx?&PrefixAlpha=4&PrefixNumeric=32) - Specifications for the older form of CCD - sometimes called a "C32".
+  * [HL7 Version 2](http://www.hl7.org/implement/standards/product_brief.cfm?product_id=185) - Specifications for all versions of HL7v2 (free account required).
+  * [OMOP](https://www.ohdsi.org/data-standardization/the-common-data-model/) - Standardized data model for many healthcare concepts, awesome Github presence including scripts for many major relational databases 
 
 ### Prescribing
   * [OpenEP](https://github.com/ehrscape/examples/tree/master/openep) - Suite of medicines management apps that improve the safety and efficiency of prescribing and medicines management.


### PR DESCRIPTION
4 changes to specifications: 
CCD/CCR - these pointed to a closed-source product's website. I changed the links to the actual standards themselves. 

HL7v2 - ubiquitous standard for most data exchange today
OMOP - very active open source data model for healthcare 