### PR TITLE
Add GitHub CI pipeline action with README.md urls validation

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -1,0 +1,43 @@
+# This is a basic workflow to check whether urls are exist by using test_script.py
+
+name: Awesome-healthcare CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+      - run: pip3 install requests 
+      - run: python test_script.py
+      
+      - name: Validate version
+        run: python --version
+
+      - name: Run simple python code
+        run: python -c 'import math; print(math.factorial(5))'
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.

--- a/test_script.py
+++ b/test_script.py
@@ -1,0 +1,45 @@
+
+from urllib.parse import urlparse
+import re
+import requests
+
+def is_url(url):
+  try:
+    result = urlparse(url)
+    return all([result.scheme, result.netloc])
+  except ValueError:
+    return False
+
+  
+def Findurl(string): 
+    regex = r"(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'\".,<>?«»“”‘’]))"
+    url = re.findall(regex,string)       
+    return [x[0] for x in url]
+
+
+f = open("README.md", "r")
+Lines = f.readlines()
+errorurls =[]
+for line in Lines: 
+    urls = Findurl(line)
+    for url in urls:
+        try:
+            #print (url)
+            request = requests.get(url,timeout=(15, 15))
+            if request.status_code != 200:
+                errorurls.append(url)
+                #print("***"+" Error")
+            #else:
+                #print("---"+" OK")
+        except:
+            errorurls.append(url)
+            #print( "***"+" Error")
+
+if len(errorurls) > 0:
+    print("******************Please doulecheck whether following urls are exist********************")
+else:
+    print("All urls in README.md are exist")   
+for error in errorurls:
+    print(error)
+
+f.close()


### PR DESCRIPTION
Add GitHub CI with python test to validate urls in README.md. 
Add test_script.py, this will retrieve every url in README.md, and test whether url is exist by send connection request. Request timeout is 15s.
For avoid sending error email, CI pipeline action for url validation console out non-exist, error connection, connection timeout urls.
This will help us to identify non-working urls in README.md when push master happens. 

More testings or/and actions could be added in CI workflow file.

#### screenshots about CI pipeline actions:

1.  CI pipeline action is triggered by push

![ci-1](https://user-images.githubusercontent.com/55629361/92420745-107dbc80-f143-11ea-819e-a2dfd8e840c9.png)

![ci-2](https://user-images.githubusercontent.com/55629361/92420748-14114380-f143-11ea-9277-2d23beae2071.png)

2.  CI pipeline action is done. No error happens. 

![ci_2](https://user-images.githubusercontent.com/55629361/92420598-5b4b0480-f142-11ea-8b65-b70e7a25f10b.png)

3. Check whether there are non-working urls in README.md

![test_result](https://user-images.githubusercontent.com/55629361/92420615-79b10000-f142-11ea-9bb7-54dc69721af2.png)
