### PR TITLE
Add HealthStack to Compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,3 +238,6 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [ID3C](https://github.com/seattleflu/id3c) - Data logistics system enabling real-time genomic epidemiology.
   * [OpenBoxes](https://github.com/openboxes/openboxes) - an Open Source Inventory and Supply Chain Management System.
   * [OpenLMIS](https://openlmis.org) - Open source, web-based, electronic logistics management information system (LMIS) software, purpose-built to manage health commodity supply chains.
+
+### Compliance
+  * [HealthStack](https://github.com/the-momentum/healthstack) - Terraform modules for building secure and compliant healthcare infrastructure on AWS.

--- a/README.md
+++ b/README.md
@@ -240,4 +240,4 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [OpenLMIS](https://openlmis.org) - Open source, web-based, electronic logistics management information system (LMIS) software, purpose-built to manage health commodity supply chains.
 
 ### Compliance
-  * [HealthStack](https://github.com/the-momentum/healthstack) - Terraform modules for building secure and compliant healthcare infrastructure on AWS.
+  * [HealthStack](https://github.com/the-momentum/healthstack) – Terraform modules for secure and compliant healthcare infrastructure on AWS.


### PR DESCRIPTION
HealthStack provides tested Terraform modules for building secure and compliant healthcare infrastructure on AWS. These modules help healthcare organizations deploy HIPAA-compliant environments with confidence, focusing on security, scalability, and compliance from day one.

This PR adds HealthStack to the ### Compliance category since ### Infrastructure doesn’t exist, though that would likely be a better fit.