### PR TITLE
Add OpenScribe to Scribe section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
 ## Contents
 
 - [EHR](#ehr)
+- [Scribe](#scribe)
 - [Specifications](#specifications)
 - [Prescribing](#prescribing)
 - [Nursing](#nursing)
@@ -56,6 +57,9 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [OSCAR EMR](https://bitbucket.org/oscaremr/oscar) - OSCAR McMaster Project.
   * [Ozone HIS](https://www.ozone-his.com) - The entreprise-grade integrated health information system built with OpenMRS 3
   * [Ripple](https://www.ripple.foundation) -  NHS-funded, community led initiative working towards an integrated Digital Care Record Platform.
+
+### Scribe
+  * [OpenScribe](https://github.com/sammargolis/OpenScribe) - Open source, local-first medical scribe platform for recording clinical encounters, transcribing audio, and generating structured draft clinical notes.
 
 ### Specifications
   * [Continuity of Care Document](https://www.hl7.org/implement/standards/product_brief.cfm?product_id=7) - Continuity of Care Document specifications


### PR DESCRIPTION
This PR proposes adding OpenScribe to the list.

OpenScribe is an open source medical AI scribe that provides the core, commoditized infrastructure for clinical documentation: local audio capture, transcription, and structured draft note generation. The platform is designed to be local-first and privacy-conscious, with encrypted local storage and no required cloud backend.

The project is MIT licensed, actively maintained, and has been used in real clinical and telehealth documentation workflows. It is intended as a base platform that organizations and developers can extend with custom integrations, templates, and workflows rather than a closed commercial service.

Repository: https://github.com/sammargolis/OpenScribe
License: MIT