### PR TITLE
Add MDTools.org - Free Open-Source Clinical Calculators

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [Intervention Engine](https://github.com/intervention-engine/ie) - Provides a web-application for data-driven team huddles.
   * [SMART Pediatric Growth Chart](https://github.com/smart-on-fhir/growth-chart-app) - Pediatric growth charts.
   * [Simple](https://github.com/simpledotorg/) - For clinicians to track patients with high blood pressure.
+  * [MDTools](https://mdtools.org) - Free, open-source clinical calculators and lab reference values. 100+ evidence-based tools including GCS, MELD, GFR, CHA₂DS₂-VASc, drug dosing calculators, and DICOM viewer. No login required.
 
 ### PHR
   * [Fasten Health](https://github.com/fastenhealth/fasten-onprem) - open-source, self-hosted, personal/family electronic medical record aggregator


### PR DESCRIPTION
## MDTools.org

[MDTools.org](https://mdtools.org) is a free, open-source suite of clinical tools for healthcare professionals:

- **100+ evidence-based clinical calculators** (GCS, MELD, GFR, CHA₂DS₂-VASc, APACHE II, NIHSS, SOFA, etc.)
- **DICOM medical image viewer** — runs entirely in-browser, zero uploads
- **Lab reference values** — normal ranges with clinical context and citations
- **Drug dosing calculators** — Semaglutide, Heparin, Vancomycin AUC, Insulin, etc.
- **Available in English and German**
- **No login, no ads, no data collection** — static HTML + vanilla JS on Cloudflare Pages

Source code: [github.com/computerdude11111/mdtools](https://github.com/computerdude11111/mdtools)

Built by [Technology Island Inc](https://mdtools.org) (Ontario, Canada).

I believe this fits well under **Applications** as it's a purpose-built clinical tool that's fully open source and free.