### PR TITLE
Add dna-claude-analysis to Bioinformatics

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
 ### Bioinformatics
   * [ADAM](https://github.com/bigdatagenomics/adam) - Genomics analysis platform.
   * [Bcbio](https://github.com/bcbio/bcbio-nextgen) - Validated, scalable, community developed variant calling, RNA-seq and small RNA analysis.
+  * [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) - Personal genome analysis toolkit with Python scripts analyzing raw DNA data across 17 categories (health risks, ancestry, pharmacogenomics, nutrition, psychology, etc.) and generating terminal-style single-page HTML visualization.
   * [FlashDeconv](https://github.com/cafferychen777/flashdeconv) - High-performance spatial transcriptomics deconvolution for cell type mapping in tissue samples.
   * [Galaxy](https://galaxyproject.org/) - Open web-based platform for data intensive biomedical research.
   * [Wregex](https://ehubio.ehu.eus/wregex/) - Amino acid motif searching software with optional Position-Specific Scoring Matrix.


### PR DESCRIPTION
## Add dna-claude-analysis to Bioinformatics

This PR adds [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the Bioinformatics section.

**dna-claude-analysis** is a personal genome analysis toolkit with Python scripts that analyze raw DNA data across 17 categories — including health risks, ancestry, pharmacogenomics, nutrition, psychology, cognitive traits, longevity, and more — and generate a terminal-style single-page HTML visualization report.

Placement is alphabetical within the Bioinformatics section, between Bcbio and FlashDeconv.