### PR TITLE
Add SubstanceWiki to Applications section

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
 ### Applications
   * [Intervention Engine](https://github.com/intervention-engine/ie) - Provides a web-application for data-driven team huddles.
   * [SMART Pediatric Growth Chart](https://github.com/smart-on-fhir/growth-chart-app) - Pediatric growth charts.
+  * [SubstanceWiki](https://github.com/yagcioglutoprak/substance_wiki) - Open-source encyclopedia of psychoactive substances with dosage guides, drug interaction checker, subjective effects index, and harm reduction information.
   * [Simple](https://github.com/simpledotorg/) - For clinicians to track patients with high blood pressure.
 
 ### PHR


### PR DESCRIPTION
## Addition

Added [SubstanceWiki](https://github.com/yagcioglutoprak/substance_wiki) to the Applications section.

SubstanceWiki is a free, open-source encyclopedia of psychoactive substances focused on harm reduction through education. It provides:

- **381 substance profiles** with dosage guides, duration timelines, and effect profiles
- **Drug interaction checker** covering 14,967 substance combinations with safety ratings
- **240+ catalogued subjective effects** linked to substances that produce them
- **Experience reports** and community insights
- **Harm reduction information** on every substance page

**Tech stack:** Next.js 16, PostgreSQL via Prisma, Tailwind CSS  
**License:** CC-BY-SA 4.0 (content), open-source codebase  
**Live site:** https://substancewiki.org

The project is actively maintained and hosted at https://github.com/yagcioglutoprak/substance_wiki.