### PR TITLE
Add CittaVerse - AI reminiscence therapy platform for dementia/MCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [Intervention Engine](https://github.com/intervention-engine/ie) - Provides a web-application for data-driven team huddles.
   * [SMART Pediatric Growth Chart](https://github.com/smart-on-fhir/growth-chart-app) - Pediatric growth charts.
   * [Simple](https://github.com/simpledotorg/) - For clinicians to track patients with high blood pressure.
+  * [CittaVerse](https://github.com/cittaverse) - AI-powered reminiscence therapy platform for dementia/MCI using narrative identity and autobiographical memory scaffolding.
 
 ### PHR
   * [Fasten Health](https://github.com/fastenhealth/fasten-onprem) - open-source, self-hosted, personal/family electronic medical record aggregator


### PR DESCRIPTION
## Summary

This PR adds CittaVerse (一念万相), an open-source AI-powered reminiscence therapy platform designed for dementia and MCI patients.

## About CittaVerse

CittaVerse is an AI reminiscence therapy platform that uses:
- Narrative identity and autobiographical memory scaffolding
- 6-dimension narrative quality scoring (novel contribution)
- Multi-session memory and context continuity
- B2B2C deployment model for eldercare institutions

## Repositories

- Core Framework: https://github.com/cittaverse/core
- Auto-Evolve Agent: https://github.com/cittaverse/auto-evolve
- Therapy Pipeline: https://github.com/cittaverse/pipeline
- Awesome Digital Therapy: https://github.com/cittaverse/awesome-digital-therapy

## Relevance

CittaVerse fits under Applications as it provides a web-based AI therapy platform for mental health/dementia care, complementing existing entries like Akello (mental health infrastructure).

---

Thank you for maintaining this valuable resource!