### PR TITLE
Add US Water Quality Data to Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
 
 ### Datasets
   * [Medical Data for Machine Learning](https://github.com/beamandrew/medical-data) - Curated list of medical data for machine learning.
+  * [US Water Quality Data](https://github.com/artakulov/us-water-quality-data) - Water quality, violations, lead/copper levels, and safety scores for 41,344 U.S. ZIP codes from EPA and 20+ federal sources. Available as JSON, CSV, npm package, and REST API.
 
 ### Design
   * [Determinants of Health](https://github.com/goinvo/HealthDeterminants) - Determinants of Health Visualization.


### PR DESCRIPTION
Adds [US Water Quality Data](https://github.com/artakulov/us-water-quality-data) to the Datasets section.

**What it is:** Open source dataset of drinking water quality metrics for all 41,344 U.S. residential ZIP codes, aggregated from EPA SDWIS and 20+ other federal sources.

**Includes:** Violations, lead/copper levels, radon zones, Home Safety Scores  
**Formats:** JSON, CSV, npm package, REST API  
**License:** CC BY 4.0  
**Updates:** Weekly