### PR TITLE
Adds wardle's Clojure/Script nhs-number library and fixes Python library name

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [Hermes](https://github.com/wardle/hermes) - a SNOMED CT terminology server.
   * [Metriport](https://github.com/metriport/metriport) - Open-source universal API for healthcare data.
   * [MITK](https://www.mitk.org/wiki/The_Medical_Imaging_Interaction_Toolkit_(MITK)) - The Medical Imaging Interaction Toolkit.
-  * [nhs-numbers](https://github.com/uk-fci/nhs-number) - Python package to provide utilities for NHS Numbers, including validity checks, normalisation, and generation.
+  * [nhs-number](https://github.com/wardle/nhs-number) - A Clojure/Script library providing validation, formatting and generation of UK NHS Numbers
+  * [nhs-number](https://github.com/uk-fci/nhs-number) - Python package to provide utilities for NHS Numbers, including validity checks, normalisation, and generation.
   * [Node HL7](https://github.com/MatthewVita/node-hl7-complete) - Node module that is bridged with the Java Hapi HL7 library.
   * [Node-hl7-parser](https://github.com/RedoxEngine/redox-hl7-v2) - Open source version of Redox's HL7 v2 to schema-fied JSON parser.
   * [php-fhir](https://github.com/dcarbone/php-fhir) - Tools for creating PHP classes from the HL7 FHIR Specification.


### PR DESCRIPTION
* Fixes Python `nhs-numbers` library to `nhs-number` which is what is it now called.
* Adds a port of the Python library to Clojure/Script, written by wardle.