### PR TITLE
Add Professional License Verification API to Nursing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
 
 ### Nursing
   * [open-eObs](https://openeobs.github.io/) - Observation and clinical assessment platform that offers a real-time view of all patients across a ward.
+  * [Professional License Verification API](https://rapidapi.com/lulzasaur9192/api/professional-license-verification) - Verify active nursing and contractor licenses across US state boards (FL, NY, CA, TX). `(Commercial Software)`
 
 ### Imaging
   * [3D Slicer](https://www.slicer.org) - Cross-platform application for analyzing, visualizing and understanding medical image data.


### PR DESCRIPTION
Adds the Professional License Verification API to the Nursing section.

This API verifies active nursing and contractor licenses across US state licensing boards (FL DOH, NY NYSED, CA CSLB, TX TDLR). Returns license status, expiration dates, and disciplinary actions.

Marked as `(Commercial Software)` per the contribution guidelines.

API documentation: https://rapidapi.com/lulzasaur9192/api/professional-license-verification