### PR TITLE
docs: add OpenMRS FHIR Analytics to EHR section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [Open Hospital](https://sourceforge.net/projects/openhospital/) - Electronic Medical Record software for underprivileged rural hospitals.
   * [openMAXIMS](https://github.com/IMS-MAXIMS/openMAXIMS) - Full Patient Administration System designed for the NHS.
   * [OpenMRS](https://openmrs.org) - Enterprise Electronic Medical Record System platform.
+  * [OpenMRS FHIR Analytics](https://github.com/google/fhir-data-pipes) - Pipeline tools for transforming OpenMRS data to FHIR-based      analytics using Apache Beam.
   * [OSCAR EMR](https://bitbucket.org/oscaremr/oscar) - OSCAR McMaster Project.
   * [Ozone HIS](https://www.ozone-his.com) - The entreprise-grade integrated health information system built with OpenMRS 3
   * [Ripple](https://www.ripple.foundation) -  NHS-funded, community led initiative working towards an integrated Digital Care Record Platform.


### PR DESCRIPTION
## What does this PR do?
Adds OpenMRS FHIR Analytics to the EHR section.

## Why?
It is an open-source tool by Google that helps convert OpenMRS 
health records into a format suitable for data analysis. 
It is actively maintained and fits well in this section 
alongside the existing OpenMRS entry.