### PR TITLE
Add OpenHealth to PHR section

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [Fasten Health](https://github.com/fastenhealth/fasten-onprem) - open-source, self-hosted, personal/family electronic medical record aggregator
   * [Tidepool](https://github.com/tidepool-org) - Data platform to reduce the burden of Type 1 Diabetes.
   * [HealthLocker](https://github.com/healthlocker/healthlocker) - Elixir-based personal health record.
+  *   * [OpenHealth](https://github.com/OpenHealthForAll/open-health) - Privacy-first AI health assistant that interprets personal health data (blood tests, checkups, family history, symptoms) with local LLM support via Ollama.
 
 ### Telemedicine
    * [Healthcare worker at home](https://hcw-at-home.com) - ​ Open Source Telehealth software 


### PR DESCRIPTION
Adds [OpenHealth](https://github.com/OpenHealthForAll/open-health) to the **Personal Health Record** section.

OpenHealth is a privacy-first AI health assistant that interprets personal health data (blood tests, checkups, family history, symptoms) with local LLM support via Ollama. It supports LLaMA, DeepSeek, GPT, Claude, and Gemini — giving patients control over their own health insights without sending data to third parties.

- **3.8k+ GitHub stars**, actively maintained
- - Fits the PHR category as it empowers individuals to manage and interpret their own health records
- - As a doctor, I found this project clinically relevant for patient-facing health data interpretation