### PR TITLE
Add SCT toolset link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [Ruby FHIR](https://github.com/fhir-crucible/fhir_client) - FHIR client implementation in Ruby.
   * [Ruby HL7](https://github.com/segfault/ruby-hl7) - Ruby HL7 library.
   * [Rust FHIR](https://github.com/itsbalamurali/rust-fhir) - Rust SDK for HL7 FHIR
+  * [sct](https://github.com/pacharanero/sct) - File-based SNOMED-CT toolset built in Rust.
   * [Scanpy](https://scanpy.readthedocs.io/) - Single-cell RNA-seq analysis library in Python.
   * [TorchXRayVision](https://github.com/mlmed/torchxrayvision) - A library for chest X-ray datasets and models. Including pre-trained models.
 


### PR DESCRIPTION
`sct` is a new, fast, local-first, SNOMED-CT toolset which loads in RF2 release files and creates local queryable files: NDJSON, SQLite, Arrow, Parquet, and many others are possible. It is free, open source, permissively licensed, and easy to use with nice documentation.