### PR TITLE
Add RCPCH Digital Growth Charts to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [Open eHealth Integration Platform](https://github.com/oehf/ipf) - An extension of the Apache Camel routing and mediation engine
   * [OpenHIM](http://openhim.org/) - Health information mediator.
   * [OpenWearables](https://github.com/the-momentum/open-wearables) - Self-hosted platform to unify wearable health data through one AI-ready API.
+  * [RCPCH Digital Growth Charts](https://growth.rcpch.ac.uk) - Open source Digital Growth Charts platform with API, CLI, Python package, React chart components.
   * [Zato](https://zato.io/en/industry/healthcare/index.html) - A Python-based ESB and integration platform for healthcare interoperability, automation and orchestration.
 
 ### Hardware


### PR DESCRIPTION
Add a link to the Royal College of Paediatrics Digital Growth Chart API Platform. It is an open source suite of tools which includes:
* International standardised repository of growth references (various licenses)
* Python Growth Centiles/SDS calculation 'engine' (MIT)
* FastAPI Growth API server (AGPL)
* React Growth Chart component (MIT)
* Documentation (CC-BY-SA-Intl-4.0)

The best entry point is the main docs site at https://growth.rcpch.ac.uk