### PR TITLE
Add Hantascan health application

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
 
 ### Applications
   * [Intervention Engine](https://github.com/intervention-engine/ie) - Provides a web-application for data-driven team huddles.
+  * [Hantascan](https://hantascan.com) - Live global hantavirus map showing reported cases, deaths, country totals, and outbreak locations.
   * [SMART Pediatric Growth Chart](https://github.com/smart-on-fhir/growth-chart-app) - Pediatric growth charts.
   * [Simple](https://github.com/simpledotorg/) - For clinicians to track patients with high blood pressure.
 


### PR DESCRIPTION
## Summary
- Add Hantascan to Applications as a public live hantavirus map resource.
- The entry follows the existing one-link, one-line description format.

## Test plan
- Documentation-only change; not run.


Made with [Cursor](https://cursor.com)