### PR TITLE
Add NotaSalud CIE reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [EDS_NLP](https://github.com/aphp/edsnlp) - provides a set of spaCy components to extract information from clinical notes written in French
   * [eds-scikit](https://github.com/aphp/eds-scikit) - a tool to assist data scientists working on the AP-HP's Clinical Data Warehouse. It is specifically targeted for OMOP-standardized data. 
   * [IHRIS](https://www.ihris.org/toolkit-new/) - Health Information System for management of human resources for health.
+  * [NotaSalud](https://notasalud.com/cie) - spanish-language ICD-10/ICD-11 search and reference site with code pages and an embeddable CIE-10 widget.
   * [OpenSAFELY](https://www.opensafely.org) - Secure analytics platform for Electronic Health Records in the NHS.
   * [Snow Owl](https://github.com/b2ihealthcare/snow-owl) - Highly scalable, open source terminology server with revision-control capabilities and collaborative authoring platform features. 
   * [Synthea Patient Generator](https://github.com/synthetichealth/synthea) - Synthetic patient generator that models the medical history of synthetic patients.


### PR DESCRIPTION
Adds NotaSalud to the Data section as a healthcare reference resource.

NotaSalud is a Spanish-language CIE-10 search/reference resource with per-code pages, a public JSON search endpoint, and an embeddable CIE-10 widget. The description is factual and avoids diagnostic or medical-advice claims.

Checked: https://notasalud.com/cie returns 200; JSON example https://notasalud.com/buscar/cie-10?q=diabetes&limit=3 returns 200. Access-Control-Allow-Origin was not observed, so CORS should be treated as No/Unknown.
