### PR TITLE
Add trove dataset to Datasets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
 
 ### Datasets
   * [Medical Data for Machine Learning](https://github.com/beamandrew/medical-data) - Curated list of medical data for machine learning.
+  * [trove](https://troveproject.com) - Reference tools and Parquet/JSON bundles for two underused U.S. healthcare datasets: FDA novel drug approvals 2021–2024 (CDER + CBER) and nonprofit hospital reporting (CMS HCRIS Worksheet S-10 + IRS 990 Schedule H side-by-side for 1,295 systems). MIT-licensed, plus two Claude Code skills.
 
 ### Design
   * [Determinants of Health](https://github.com/goinvo/HealthDeterminants) - Determinants of Health Visualization.


### PR DESCRIPTION
Adds trove (https://troveproject.com) to the Datasets section.

trove publishes Parquet/JSON/CSV bundles for two public-domain U.S. healthcare datasets that are widely cited
but ship in awkward raw forms — CMS Medicare Cost Reports (100K-row long-skinny CSVs) and IRS 990 Schedule H
(XML bulk ZIPs). It also indexes 218 FDA novel drug approvals from 2021–2024 (both CDER and CBER), with deep
links to each approval's full document package.

MIT-licensed at https://github.com/cbetz/trove. Underlying data is U.S. government work, public domain.