### PR TITLE
Add UNMIRI NGS interpretation schema (Apache 2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [Bcbio](https://github.com/bcbio/bcbio-nextgen) - Validated, scalable, community developed variant calling, RNA-seq and small RNA analysis.
   * [FlashDeconv](https://github.com/cafferychen777/flashdeconv) - High-performance spatial transcriptomics deconvolution for cell type mapping in tissue samples.
   * [Galaxy](https://galaxyproject.org/) - Open web-based platform for data intensive biomedical research.
+  * [unmiri-ngs-fhir-schema](https://github.com/unmirihealth/unmiri-ngs-fhir-schema) - Apache-2.0 vendor-agnostic JSON Schema (Draft 2020-12) API contract for cross-vendor NGS interpretation output, aligned with the HL7 FHIR Genomics IG. Ships TypeScript types, Python pydantic models, worked examples, and a validator.
   * [Wregex](https://ehubio.ehu.eus/wregex/) - Amino acid motif searching software with optional Position-Specific Scoring Matrix.
 
 ### Books


### PR DESCRIPTION
Adds an Apache-2.0 open schema for cross-vendor NGS (next-generation sequencing) interpretation output in oncology, in the Bioinformatics section.

The repo contains:
- JSON Schemas (Draft 2020-12) for the NGS-interpretation-response shape (variants, biomarkers, companion-diagnostic flags, trial matches, contraindications, specimen, audit)
- Hand-written TypeScript types and Python pydantic v2 models
- Eight worked synthetic example payloads
- A validator script

It is a developer-ergonomic data contract aligned with the HL7 FHIR Genomics Implementation Guide, not a literal FHIR Bundle profile. 100% free, no registration, no API key required.
