### PR TITLE
Add Superhighway to Research section

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
 ### Research
   * [i2b2](https://www.i2b2.org) - Research data warehouse.
   * [LabKey Server](https://www.labkey.com/products-services/labkey-server/) - Platform for Translational Research.
+  * [Superhighway](https://superhighway.walls.sh) - Web search API for AI agents (search, news, scrape, research endpoints) usable for biomedical literature and clinical-trial research; pay-per-call with USDC via x402 or free API key. MCP server: `npx -y superhighway-mcp`.
 
 ### Integration
   * [FHIR Converter](https://github.com/microsoft/FHIR-Converter) - an open source project that enables conversion of health data from legacy formats to FHIR.


### PR DESCRIPTION
## Add Superhighway — web search API for AI agents

**[Superhighway](https://superhighway.walls.sh)** is a web search API built for AI agents: search, news, images, scrape, and research endpoints.

The [Biotech Pipeline Research Agent guide](https://superhighway.walls.sh/guides/biotech-research-agent) shows how to use it for biotech pipeline research and clinical trial competitive intelligence — querying ClinicalTrials.gov/STAT News/Fierce Pharma, classifying by drug modality (mAb, ADC, cell therapy, gene therapy, RNA therapy) and therapeutic area.

- **Auth**: `Authorization: Bearer YOUR_API_KEY` or pay-per-call with USDC via x402 (no signup required)
- **MCP server**: `npx -y superhighway-mcp`
- **Rate**: $0.002/call

Added under the **Research** section.
