### PR TITLE
Add MedikQuantis

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
 
 ### Applications
   * [Intervention Engine](https://github.com/intervention-engine/ie) - Provides a web-application for data-driven team huddles.
+  * [MedikQuantis](https://medikquantis.me) - Open source (MIT) clinical calculators: 49 scores across 16 specialties in Catalan, Spanish and English, with clinician and patient modes, a free REST API and SMART on FHIR support.
   * [SMART Pediatric Growth Chart](https://github.com/smart-on-fhir/growth-chart-app) - Pediatric growth charts.
   * [Simple](https://github.com/simpledotorg/) - For clinicians to track patients with high blood pressure.
 


### PR DESCRIPTION
Adding MedikQuantis to the Applications section.

It's an open-source (MIT) set of clinical calculators — 49 scores across 16 specialties — localised in Catalan, Spanish and English, with a clinician view and a plain-language patient view on every score, each citing its primary-literature reference. It runs in production at https://medikquantis.me, with a free REST API (OpenAPI) and SMART on FHIR support. Each calculator has a 1:1 unit test.

Repo: https://github.com/laurapiro17/medikquantis