### PR TITLE
Add OOPI - Open Out-of-Pocket Pricing Index to Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
 
 ### Datasets
   * [Medical Data for Machine Learning](https://github.com/beamandrew/medical-data) - Curated list of medical data for machine learning.
+  * [OOPI - Open Out-of-Pocket Pricing Index](https://www.rxpricetracker.com/data) - Monthly cross-source US cash drug prices across CVS, GoodRx, Costco, Cost Plus Drugs, Amazon Pharmacy, SingleCare. 109 molecules, with capture URLs. CC-BY-4.0. Also mirrored on [HuggingFace](https://huggingface.co/datasets/pharmax-ai/oopi-pricing-index), [Zenodo (DOI 10.5281/zenodo.20969232)](https://zenodo.org/record/20969232), and [Kaggle](https://www.kaggle.com/datasets/zackkmichael/oopi-us-cash-drug-prices).
 
 ### Design
   * [Determinants of Health](https://github.com/goinvo/HealthDeterminants) - Determinants of Health Visualization.


### PR DESCRIPTION
Adds OOPI - Open Out-of-Pocket Pricing Index to the Datasets section.

**What it is**: Monthly cross-source US cash drug prices across CVS, GoodRx, Costco, Mark Cuban Cost Plus Drugs, Amazon Pharmacy, SingleCare. 109 molecules tracked with capture URLs and dates per observation.

**License**: CC-BY-4.0

**Mirrors** (same data, multiple discovery surfaces):
- HuggingFace Datasets: https://huggingface.co/datasets/pharmax-ai/oopi-pricing-index
- Zenodo (DOI 10.5281/zenodo.20969232): https://zenodo.org/record/20969232
- Kaggle: https://www.kaggle.com/datasets/zackkmichael/oopi-us-cash-drug-prices

The Datasets section currently has 1 entry. OOPI is a publicly-published, source-cited, monthly-refreshed dataset of US cash drug prices across multiple retailers - valuable for healthcare-economics research, ML pricing models, and patient-decision tools.

Happy to shorten the entry if you'd prefer.