### PR TITLE
Add Verified Supplement Evidence Database to Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
 
 ### Datasets
   * [Medical Data for Machine Learning](https://github.com/beamandrew/medical-data) - Curated list of medical data for machine learning.
+  * [Verified Supplement Evidence Database](https://huggingface.co/datasets/erinheit451/verified-supplement-evidence) - CC-BY dataset of supplement clinical evidence, dosing, form bioavailability and drug-nutrient interactions, with a PubMed PMID on every claim.
 
 ### Design
   * [Determinants of Health](https://github.com/goinvo/HealthDeterminants) - Determinants of Health Visualization.


### PR DESCRIPTION
Adds the **Verified Supplement Evidence Database** to the Datasets section — an open CC-BY-4.0 dataset (DOI 10.57967/hf/9356) of dietary-supplement clinical evidence: dosing, form/bioavailability comparisons, medication-nutrient interactions, and cost-per-effective-dose product data. Every clinical claim carries a PubMed PMID. 7 CSV tables, directly downloadable (Hugging Face + publisher site), plus a free no-auth JSON API. Format matches existing entries.