### PR TITLE
Add Beacon to Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
    * [Healthcare worker at home](https://hcw-at-home.com) - ​ Open Source Telehealth software 
 
 ### Research
+  * [Beacon](https://beacontrials.ca) - Bilingual (English/French) patient-facing search across the full ClinicalTrials.gov registry, with plain-language eligibility explanations and no data collection.
   * [i2b2](https://www.i2b2.org) - Research data warehouse.
   * [LabKey Server](https://www.labkey.com/products-services/labkey-server/) - Platform for Translational Research.
 


### PR DESCRIPTION
Adds [Beacon](https://beacontrials.ca), a free, open-source ([repo](https://github.com/stemcat/beacon)), bilingual (EN/FR) patient-facing search over the full ClinicalTrials.gov registry, with plain-language eligibility explanations. It is a static web app in production at beacontrials.ca; searches run browser-direct against the registry API and no user data is collected. Disclosure: I am the author.