### PR TITLE
Add o2ring-analyzer to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [OpenHIM](http://openhim.org/) - Health information mediator.
   * [OpenWearables](https://github.com/the-momentum/open-wearables) - Self-hosted platform to unify wearable health data through one AI-ready API.
   * [Zato](https://zato.io/en/industry/healthcare/index.html) - A Python-based ESB and integration platform for healthcare interoperability, automation and orchestration.
+  * [o2ring-analyzer](https://github.com/nighttimecf/o2ring-analyzer) - Analyzer for overnight pulse-oximetry recordings from Wellue O2Ring: SpO2 statistics, ODI, desaturation events.
 
 ### Hardware
   * [Gluco](https://github.com/nebulabio/gluco) - Glucometer.


### PR DESCRIPTION
Adding o2ring-analyzer under Hardware, alongside the other device-specific tools (Gluco, OpenAPS).

The Wellue O2Ring is a widely used continuous pulse oximeter for overnight SpO2 recording. Its vendor software exports per-second readings as CSV but produces no aggregate metrics, leaving users unable to compute the indices described in the sleep medicine literature.

This tool implements those calculations: oxygen desaturation index under both 3% and 4% threshold definitions, event-level desaturation detection with durations, nadir SpO2, and time below threshold. Output as CSV, JSON or Excel.

Disclosure: I am the author.

- MIT licensed, actively maintained
- PyPI: https://pypi.org/project/o2ring-analyzer/
- Archived with DOI: https://doi.org/10.5281/zenodo.21439509
- Test suite and CI configured