### PR TITLE
Add wellnizz and Open Wearables to healthcare

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [NextGen Connect Integration Engine](https://github.com/nextgenhealthcare/connect) - The swiss army knife of healthcare integration.
   * [Open eHealth Integration Platform](https://github.com/oehf/ipf) - An extension of the Apache Camel routing and mediation engine
   * [OpenHIM](http://openhim.org/) - Health information mediator.
-  * [Open Wearables](https://github.com/the-momentum/open-wearables) - Agent-native wearable data unification platform. Ingests from WHOOP, Oura, Garmin, Suunto, Polar, Fitbit, Strava, Apple HealthKit, Samsung Health, Google Health Connect. FastAPI + MCP server. MIT licensed.
   * [Zato](https://zato.io/en/industry/healthcare/index.html) - A Python-based ESB and integration platform for healthcare interoperability, automation and orchestration.
 
 ### Hardware

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [Fasten Health](https://github.com/fastenhealth/fasten-onprem) - open-source, self-hosted, personal/family electronic medical record aggregator
   * [Tidepool](https://github.com/tidepool-org) - Data platform to reduce the burden of Type 1 Diabetes.
   * [HealthLocker](https://github.com/healthlocker/healthlocker) - Elixir-based personal health record.
-  * [wellnizz](https://github.com/liveforeverbetter/wellnizz) - Agent-native health API combining 168+ biomarkers, wearable data (WHOOP, Oura, Garmin), and Whole Genome Sequencing (ClinVar, CPIC, PRS) into personalized dashboards and action plans. REST + MCP. Self-hostable via Docker. AGPL-3.0.
+  * [wellnizz](https://github.com/liveforeverbetter/wellnizz) - Agent-first API for genetics (WGS, ClinVar, CPIC, PRS), 168+ biomarkers, and wearables (WHOOP, Oura, Garmin). REST + MCP. Self-hostable via Docker. AGPL-3.0.
 
 ### Telemedicine
    * [Healthcare worker at home](https://hcw-at-home.com) - ​ Open Source Telehealth software 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [Fasten Health](https://github.com/fastenhealth/fasten-onprem) - open-source, self-hosted, personal/family electronic medical record aggregator
   * [Tidepool](https://github.com/tidepool-org) - Data platform to reduce the burden of Type 1 Diabetes.
   * [HealthLocker](https://github.com/healthlocker/healthlocker) - Elixir-based personal health record.
+  * [wellnizz](https://github.com/liveforeverbetter/wellnizz) - Agent-native health API combining 168+ biomarkers, wearable data (WHOOP, Oura, Garmin), and Whole Genome Sequencing (ClinVar, CPIC, PRS) into personalized dashboards and action plans. REST + MCP. Self-hostable via Docker. AGPL-3.0.
 
 ### Telemedicine
    * [Healthcare worker at home](https://hcw-at-home.com) - ​ Open Source Telehealth software 
@@ -188,7 +189,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [NextGen Connect Integration Engine](https://github.com/nextgenhealthcare/connect) - The swiss army knife of healthcare integration.
   * [Open eHealth Integration Platform](https://github.com/oehf/ipf) - An extension of the Apache Camel routing and mediation engine
   * [OpenHIM](http://openhim.org/) - Health information mediator.
-  * [OpenWearables](https://github.com/the-momentum/open-wearables) - Self-hosted platform to unify wearable health data through one AI-ready API.
+  * [Open Wearables](https://github.com/the-momentum/open-wearables) - Agent-native wearable data unification platform. Ingests from WHOOP, Oura, Garmin, Suunto, Polar, Fitbit, Strava, Apple HealthKit, Samsung Health, Google Health Connect. FastAPI + MCP server. MIT licensed.
   * [Zato](https://zato.io/en/industry/healthcare/index.html) - A Python-based ESB and integration platform for healthcare interoperability, automation and orchestration.
 
 ### Hardware


### PR DESCRIPTION
## Changes

- **wellnizz**: Added to PHR section - Agent-native health API combining 168+ biomarkers, wearable data (WHOOP, Oura, Garmin), and Whole Genome Sequencing into personalized dashboards and action plans.
- **Open Wearables**: Updated existing entry in Integration section - Agent-native wearable data unification platform ingesting from WHOOP, Oura, Garmin, Suunto, Polar, Fitbit, Strava, Apple HealthKit, Samsung Health, Google Health Connect.