### PR TITLE
Add GLP-1 Telehealth Rules by US State dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [Synthea Patient Generator](https://github.com/synthetichealth/synthea) - Synthetic patient generator that models the medical history of synthetic patients.
 
 ### Datasets
+  * [GLP-1 Telehealth Rules by US State](https://www.pallashealth.co/glp-1/telehealth-rules) - Weekly-verified open dataset (CC BY 4.0, CSV/JSON downloads, RSS changelog, [DOI](https://doi.org/10.5281/zenodo.21892535)) of US state telehealth video-visit requirements, Medicaid GLP-1 coverage, and nurse practitioner prescriptive authority with statute citations.
   * [Medical Data for Machine Learning](https://github.com/beamandrew/medical-data) - Curated list of medical data for machine learning.
 
 ### Design


### PR DESCRIPTION
Adds an open dataset to the **Datasets** section: GLP-1 Telehealth Rules by US State.

**What it is:** which of the 51 US jurisdictions (50 states + DC) require a live video visit to start GLP-1 treatment via telehealth, plus each jurisdiction's medical board, Medicaid GLP-1 coverage status, and nurse practitioner prescriptive-authority classification (full/reduced/restricted) with statute citations.

**Why it fits the list's conditions:**
- Openly licensed: CC BY 4.0, machine-readable CSV + JSON downloads
- Maintained: re-verified weekly by an automated job; every substantive change is dated in a public changelog (also published as RSS)
- Citable: archived on Zenodo with a versioned DOI — https://doi.org/10.5281/zenodo.21892535 (mirrors on [Hugging Face](https://huggingface.co/datasets/pallas-health/glp1-telehealth-rules-us) and [Kaggle](https://www.kaggle.com/datasets/adampagon/glp1-telehealth-rules-us))
- The linked page is the dataset itself (table + downloads + changelog), not a product page

Placed alphabetically in the Datasets section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)