### PR TITLE
Add who-growth-standards to Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
   * [Rust FHIR](https://github.com/itsbalamurali/rust-fhir) - Rust SDK for HL7 FHIR
   * [Scanpy](https://scanpy.readthedocs.io/) - Single-cell RNA-seq analysis library in Python.
   * [TorchXRayVision](https://github.com/mlmed/torchxrayvision) - A library for chest X-ray datasets and models. Including pre-trained models.
+  * [who-growth-standards](https://github.com/SunnySeedApp/who-growth-standards) - TypeScript library for the WHO Child Growth Standards. Z-scores and percentiles computed locally from the official LMS tables, no network calls.
 
 ### Applications
   * [Intervention Engine](https://github.com/intervention-engine/ie) - Provides a web-application for data-driven team huddles.


### PR DESCRIPTION
Adds a TypeScript library for the WHO Child Growth Standards.

It bundles the official WHO expanded tables - weight-for-age,
length/height-for-age, head-circumference-for-age and BMI-for-age at daily
resolution (0–1856 days), plus weight-for-length and weight-for-height at
0.1 cm steps, both sexes - and computes z-scores and percentiles locally.
No network calls, no runtime dependencies.

The tables are generated from cdn.who.int by a script in the repo rather
than hand-copied, so they can be regenerated against future WHO revisions
in one command.

Published on npm: https://www.npmjs.com/package/who-growth-standards
MIT licensed, typed, tested.
