### PR TITLE
Add Urgences Québec to Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Curated list of awesome open source healthcare software, libraries, tools and re
 
 ### Datasets
   * [Medical Data for Machine Learning](https://github.com/beamandrew/medical-data) - Curated list of medical data for machine learning.
+  * [Urgences Québec](https://sante.handled.tools/en/donnees) - JSON API for emergency-room occupancy at 120 Quebec emergency departments, updated hourly, no key, with an archive back to 10 August 2026.
 
 ### Design
   * [Determinants of Health](https://github.com/goinvo/HealthDeterminants) - Determinants of Health Visualization.


### PR DESCRIPTION
Adds Urgences Québec to Datasets.

It is a free JSON API over the hourly emergency-department occupancy file that Quebec's health ministry publishes: 120 emergency departments, stretcher occupancy, patients present, patients waiting past 24h and 48h, and mean stay durations. No key, no account, `Access-Control-Allow-Origin: *`.

The reason it is a dataset and not just a mirror: the ministry overwrites its file every hour and keeps roughly a week. This one keeps every hourly reading since 10 August 2026, so you can query a single facility's history rather than only its current state.

Endpoints are documented at the linked page (`/api/now`, `/api/facilities`, `/api/facility/<permit>/history`, `/api/cliniques`, `/api/chirurgies`).

Disclosure: I run this. Source is the MSSS open file, attributed on the page. Happy to move it to Data or drop it if Datasets is meant for ML corpora only.
